### PR TITLE
Add forms for Civi Event Cart, correct check against form event_id

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -152,6 +152,7 @@ function cividiscount_civicrm_buildForm($fname, &$form) {
             'CRM_Event_Form_Registration_Register',
             //'CRM_Event_Form_Registration_AdditionalParticipant',
             'CRM_Contribute_Form_Contribution_Main',
+            'CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices',
           ))) {
 
     // Display the discount textfield for online events (including
@@ -161,6 +162,7 @@ function cividiscount_civicrm_buildForm($fname, &$form) {
 
     if ( in_array($fname, array(
       'CRM_Event_Form_Registration_Register',
+      'CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices',
       //'CRM_Event_Form_Registration_AdditionalParticipant'
     ))) {
       $discountCalculator = new CRM_CiviDiscount_DiscountCalculator('event', $form->getVar('_eventId'), $form->getContactID(), NULL, TRUE);
@@ -180,7 +182,7 @@ function cividiscount_civicrm_buildForm($fname, &$form) {
     }
 
     if (empty($ids)) {
-      $ids = _cividiscount_get_discounted_priceset_ids();
+      $ids = _cividiscount_get_discounted_event_ids();
 
       if (!empty($ids)) {
         if(in_array($form->getVar('_eventId'), $ids)){


### PR DESCRIPTION
This will add the Discount code textbox to the shopping cart checkout form - but more changes are needed to make discounts work in the cart, which I can submit to the Event/Cart/Form/Checkout modules, since the cart code seems not to follow the regular Registration model.
Also, at line 187+ the code uses the form eventId, so it should check if it's in the event Id array, not priceset Ids
